### PR TITLE
Fix facilitator docs for exercise C

### DIFF
--- a/Facilitator-Notes/C_ExtractAndOverrideCall.md
+++ b/Facilitator-Notes/C_ExtractAndOverrideCall.md
@@ -12,7 +12,7 @@ Which option did you use?
 
 * extract and override (static) call
   * minimal code change, fully automated refactoring, no magic
-  * subclass of `Discount` needed in test
+  * subclass of `Checkout` needed in test
 
 * wrap the `ReceiptRepository` singleton in a class and inject into `Checkout`.
   * more work, higher risk


### PR DESCRIPTION
Small fix on facilitator docs for exercise C, it should say Checkout class instead of Discount.